### PR TITLE
Update apache-libcloud instructions for RHEL

### DIFF
--- a/docs/PROVISIONING_GCP.md
+++ b/docs/PROVISIONING_GCP.md
@@ -54,15 +54,18 @@ Take note of the service account id (it will look like an email address). We wil
 Install the following software:
 
 ```
-yum install ansible
-pip install apache-libcloud
+yum install ansible python-libcloud
 ```
 
-follow these [instructions](https://cloud.google.com/sdk/downloads#yum) to install the gcp CLI (`gcloud`).
+>Note: Red Hat Enterprise Linux does not provide the `pip` command outside of Software Collection Libraries (SCL).
+>For other distributions, the command `pip install apache-libcloud` may be used. Packages installed using `pip`
+>within SCL may require additional configuration of Ansible to use the SCL environment.
+
+To install the GCP CLI (`gcloud`), follow these [instructions](https://cloud.google.com/sdk/downloads#yum).
 
 ### Configure the casl-environment
 
-clone the ansible repo (you may also want to use a specific verison) and install the necessary galaxy repo.
+Clone the ansible repo (you may also want to use a specific verison) and install the necessary galaxy repo.
 ```
 git clone https://github.com/redhat-cop/casl-ansible
 cd casl-ansible


### PR DESCRIPTION
Updated the `yum` command to include python-libcloud (Apache Libcloud) for RHEL and kept the `pip` in a note along with caveats of using SCL with Ansible to use `pip`. Minor syntax changes.

#### What does this PR do?
The `pip` command is not available in Red Hat Enterprise Linux without SCL and is difficult to use with Ansible due to environment issues.

#### How should this be manually tested?
Use the following command and ensure the instructions work with the version of Apache Libcloud provided by Red Hat.

`sudo yum install -y python-libcloud`

#### Who would you like to review this?
cc: @redhat-cop/casl